### PR TITLE
Add recursive atlas directory helper

### DIFF
--- a/src/silky/atlas.nim
+++ b/src/silky/atlas.nim
@@ -243,6 +243,13 @@ proc addDir*(builder: AtlasBuilder, path: string, removePrefix: string = "") =
       key.removeSuffix(".png")
       builder.atlas.entries[key] = entry
 
+proc addDirRecursive*(builder: AtlasBuilder, path: string, removePrefix: string = "") =
+  ## Add all images in the given directory and its subdirectories to the atlas.
+  builder.addDir(path, removePrefix)
+  for entry in walkDir(path):
+    if entry.kind == pcDir:
+      builder.addDirRecursive(entry.path, removePrefix)
+
 proc addFont*(builder: AtlasBuilder, path: string, name: string, size: float32, chars: seq[string] = AsciiGlyphs, subpixelSteps: int = 0) =
   ## Add a font to the atlas.
   let fontAtlas = FontAtlas()


### PR DESCRIPTION
## Summary
- add an exported addDirRecursive helper to silky/atlas
- recurse through subdirectories while preserving existing removePrefix behavior
- keep atlas-building callers on the library API instead of local shims

## Testing
- nim c tests\test_atlas_png.nim
