### PR TITLE
SilkyPR: Fix DX12 and Vulkan masking paths

### DIFF
--- a/src/silky/drawers/dx12.nim
+++ b/src/silky/drawers/dx12.nim
@@ -3,7 +3,6 @@ when not defined(windows):
 
 import
   pixie, vmath, windy,
-  windy/platforms/win32/windefs,
   pkg/dx12, pkg/dx12/context
 
 const
@@ -58,6 +57,7 @@ proc normalizeVertices(
       1.0'f - (p.y / height) * 2.0'f
     )
     vertices[i].uv = vertices[i].uv / atlasSize
+    vertices[i].maskUv = vertices[i].maskUv / atlasSize
 
 proc createVertexBuffer(state: Drawer, maxVertexCount: int) =
   ## Creates or replaces the persistently mapped upload vertex buffer.
@@ -139,7 +139,7 @@ proc uploadTexture(state: Drawer, image: Image) =
   )
 
   var footprint = D3D12_PLACED_SUBRESOURCE_FOOTPRINT()
-  var numRows: UINT
+  var numRows: uint32
   var rowSize: UINT64
   var totalBytes: UINT64
   state.ctx.device.getCopyableFootprints(

--- a/src/silky/drawers/vk14.nim
+++ b/src/silky/drawers/vk14.nim
@@ -65,6 +65,7 @@ proc normalizeVertices(
       (p.y / height) * 2.0'f - 1.0'f
     )
     vertices[i].uv = vertices[i].uv / atlasSize
+    vertices[i].maskUv = vertices[i].maskUv / atlasSize
 
 proc requiresSwapChainRecreate(vkResult: VkResult): bool =
   let code = vkResult.int32

--- a/tests/manual_masking.nim
+++ b/tests/manual_masking.nim
@@ -1,7 +1,7 @@
 ## Manual test for drawImage with mask support.
 
 import
-  opengl, windy, vmath, chroma,
+  windy, vmath, chroma,
   silky
 
 let builder = newAtlasBuilder(1024, 4)


### PR DESCRIPTION
## Summary
- fix the DX12 masking path and keep `manual_masking` backend-agnostic
- normalize Vulkan mask UVs so masked+tinted sprites sample the right gradient
- pair with the vk14 PR for the Vulkan color-space presentation fix

## Testing
- `nim r -d:useDirectX .\tests\manual_masking.nim`
- `nim r -d:useVulkan .\tests\manual_masking.nim`