### PR TITLE
Reduce ASCII text render allocations

### DIFF
--- a/src/silky/atlas.nim
+++ b/src/silky/atlas.nim
@@ -36,6 +36,16 @@ type
     advance*: float32
     kerning*: Table[string, float32]
 
+  AsciiLetterEntry* = object
+    ## Runtime glyph metrics without the per-glyph kerning table.
+    x*: int
+    y*: int
+    boundsX*: float32
+    boundsY*: float32
+    boundsWidth*: float32
+    boundsHeight*: float32
+    advance*: float32
+
   FontAtlas* = ref object
     ## The font atlas that is used to draw text.
     size*: float32
@@ -45,6 +55,9 @@ type
     lineGap*: float32
     subpixelSteps*: int
     entries*: Table[string, seq[LetterEntry]]
+    asciiEntries: array[128, seq[AsciiLetterEntry]]
+    asciiKerning: array[128, array[128, float32]]
+    fallbackEntries: seq[AsciiLetterEntry]
 
   SilkyAtlas* = ref object
     ## The pixel atlas that gets converted to JSON.
@@ -59,6 +72,86 @@ type
     allocator*: SkylineAllocator
     atlasImage*: Image
     atlas*: SilkyAtlas
+
+proc toAsciiLetterEntry(entry: LetterEntry): AsciiLetterEntry =
+  AsciiLetterEntry(
+    x: entry.x,
+    y: entry.y,
+    boundsX: entry.boundsX,
+    boundsY: entry.boundsY,
+    boundsWidth: entry.boundsWidth,
+    boundsHeight: entry.boundsHeight,
+    advance: entry.advance
+  )
+
+proc prepareFastLookups(fontAtlas: FontAtlas) =
+  ## Builds runtime-only ASCII lookup tables for hot text drawing paths.
+  for i in 0 ..< fontAtlas.asciiEntries.len:
+    fontAtlas.asciiEntries[i].setLen(0)
+  fontAtlas.fallbackEntries.setLen(0)
+  for left in 0 ..< fontAtlas.asciiKerning.len:
+    for right in 0 ..< fontAtlas.asciiKerning[left].len:
+      fontAtlas.asciiKerning[left][right] = 0
+
+  for code in 0 ..< 128:
+    let key = $chr(code)
+    if key in fontAtlas.entries:
+      let sourceEntries = fontAtlas.entries[key]
+      fontAtlas.asciiEntries[code].setLen(sourceEntries.len)
+      for i in 0 ..< sourceEntries.len:
+        fontAtlas.asciiEntries[code][i] =
+          sourceEntries[i].toAsciiLetterEntry()
+
+  if "?" in fontAtlas.entries:
+    let sourceEntries = fontAtlas.entries["?"]
+    fontAtlas.fallbackEntries.setLen(sourceEntries.len)
+    for i in 0 ..< sourceEntries.len:
+      fontAtlas.fallbackEntries[i] = sourceEntries[i].toAsciiLetterEntry()
+
+  for left in 0 ..< 128:
+    let leftKey = $chr(left)
+    if leftKey notin fontAtlas.entries:
+      continue
+    let leftEntries = fontAtlas.entries[leftKey]
+    if leftEntries.len == 0 or leftEntries[0].kerning.len == 0:
+      continue
+    for right in 0 ..< 128:
+      let rightKey = $chr(right)
+      if rightKey in leftEntries[0].kerning:
+        fontAtlas.asciiKerning[left][right] = leftEntries[0].kerning[rightKey]
+
+proc prepareFastLookups*(atlas: SilkyAtlas) =
+  ## Builds runtime-only fast lookup tables after JSON atlas decoding.
+  for fontAtlas in atlas.fonts.mvalues:
+    fontAtlas.prepareFastLookups()
+
+proc lookupAsciiLetter*(
+  fontAtlas: FontAtlas,
+  ch: char,
+  variant: int,
+  entry: var AsciiLetterEntry
+): bool =
+  ## Looks up one ASCII glyph without allocating a string key.
+  let code = ord(ch)
+  if code < 128:
+    let entries = fontAtlas.asciiEntries[code]
+    if entries.len > 0:
+      entry = entries[min(variant, entries.len - 1)]
+      return true
+  if fontAtlas.fallbackEntries.len > 0:
+    entry = fontAtlas.fallbackEntries[0]
+    return true
+  false
+
+proc lookupAsciiKerning*(fontAtlas: FontAtlas, left, right: char): float32 =
+  ## Returns cached ASCII kerning without allocating string keys.
+  let
+    leftCode = ord(left)
+    rightCode = ord(right)
+  if leftCode < 128 and rightCode < 128:
+    fontAtlas.asciiKerning[leftCode][rightCode]
+  else:
+    0.0'f32
 
 proc newAtlasBuilder*(size, margin: int): AtlasBuilder =
   ## Generate a pixel atlas from the given directories.
@@ -186,7 +279,8 @@ proc extractAtlasJsonFromPng*(pngData: string): string =
 proc readAtlasFromPng*(path: string): SilkyAtlas =
   ## Reads and decodes the atlas JSON embedded in an atlas PNG file.
   try:
-    extractAtlasJsonFromPng(readFile(path)).fromJson(SilkyAtlas)
+    result = extractAtlasJsonFromPng(readFile(path)).fromJson(SilkyAtlas)
+    result.prepareFastLookups()
   except IOError as e:
     raise newException(SilkyAtlasError, e.msg, e)
 
@@ -197,6 +291,7 @@ proc readAtlas*(
   try:
     let pngData = readFile(path)
     result.atlas = extractAtlasJsonFromPng(pngData).fromJson(SilkyAtlas)
+    result.atlas.prepareFastLookups()
     result.image = decodePng(pngData).convertToImage()
   except IOError as e:
     raise newException(SilkyAtlasError, e.msg, e)
@@ -332,6 +427,7 @@ proc addFont*(builder: AtlasBuilder, path: string, name: string, size: float32, 
       let kerning = typeface.getKerningAdjustment(rune, rune2)
       if kerning != 0:
         fontAtlas.entries[glyphStr][0].kerning[glyphStr2] = kerning * scale
+  fontAtlas.prepareFastLookups()
   builder.atlas.fonts[name] = fontAtlas
 
 proc write*(builder: AtlasBuilder, outputPngPath: string) =

--- a/src/silky/contexts.nim
+++ b/src/silky/contexts.nim
@@ -426,6 +426,12 @@ proc drawTriangle*(
       maskUv: vec2(-1, -1)
     ))
 
+proc isAsciiText(text: string): bool =
+  for ch in text:
+    if ord(ch) >= 128:
+      return false
+  true
+
 proc drawText*(
   sk: Silky,
   font: string,
@@ -454,7 +460,6 @@ proc drawText*(
   let
     fontData = sk.atlas.fonts[font]
     maxPos = pos + vec2(maxWidth, maxHeight)
-    runedText = text.toRunes
     hasSubpixel = fontData.subpixelSteps > 0
     layer = sk.drawer.currentLayer
     needsHAlign = hAlign != LeftAlign
@@ -497,6 +502,105 @@ proc drawText*(
         sk.drawer.layers[layer][j].pos.x += dx
     lineStartIdx = sk.drawer.layers[layer].len
 
+  if text.isAsciiText():
+    var i = 0
+    while i < text.len:
+      let ch = text[i]
+
+      if ch == '\n':
+        alignLine(currentPos.x - pos.x)
+        currentPos.x = pos.x
+        currentPos.y += fontData.lineHeight
+        inc i
+        continue
+
+      if wordWrap and currentPos.x > pos.x and ch != ' ':
+        let isWordStart =
+          i == 0 or
+          text[i - 1] == ' ' or
+          text[i - 1] == '\n'
+        if isWordStart:
+          var
+            wordW = 0.0'f
+            j = i
+          while j < text.len and text[j] != ' ' and text[j] != '\n':
+            var wordEntry: AsciiLetterEntry
+            if fontData.lookupAsciiLetter(text[j], 0, wordEntry):
+              wordW += wordEntry.advance
+            inc j
+          if currentPos.x + wordW > pos.x + maxWidth:
+            alignLine(currentPos.x - pos.x)
+            currentPos.x = pos.x
+            currentPos.y += fontData.lineHeight
+
+      let variant =
+        if hasSubpixel:
+          let frac = currentPos.x - currentPos.x.floor
+          (frac * fontData.subpixelSteps.float32).int mod
+            fontData.subpixelSteps
+        else:
+          0
+
+      var entry: AsciiLetterEntry
+      if not fontData.lookupAsciiLetter(ch, variant, entry):
+        inc i
+        continue
+
+      if currentPos.x >= maxPos.x:
+        if wordWrap:
+          alignLine(currentPos.x - pos.x)
+          currentPos.x = pos.x
+          currentPos.y += fontData.lineHeight
+        elif glyphClip:
+          while i < text.len and text[i] != '\n':
+            inc i
+          continue
+
+      if glyphClip and currentPos.y + entry.boundsY >= maxPos.y:
+        break
+
+      if entry.boundsWidth > 0 and entry.boundsHeight > 0:
+        let glyphPos = vec2(
+          floor(currentPos.x) + entry.boundsX,
+          round(currentPos.y + entry.boundsY)
+        )
+        sk.drawQuad(
+          glyphPos,
+          vec2(entry.boundsWidth, entry.boundsHeight),
+          vec2(entry.x.float32, entry.y.float32),
+          vec2(entry.boundsWidth, entry.boundsHeight),
+          color,
+          textClip[0],
+          textClip[1]
+        )
+
+      currentPos.x += entry.advance
+      if i < text.len - 1:
+        currentPos.x += fontData.lookupAsciiKerning(ch, text[i + 1])
+
+      inc i
+
+    alignLine(currentPos.x - pos.x)
+
+    if needsVAlign:
+      let
+        textHeight =
+          currentPos.y - pos.y - fontData.ascent + fontData.lineHeight
+        dy =
+          case vAlign:
+          of TopAlign:
+            0.0'f
+          of MiddleAlign:
+            floor((maxHeight - textHeight) * 0.5)
+          of BottomAlign:
+            floor(maxHeight - textHeight)
+      if dy != 0:
+        for j in textStartIdx ..< sk.drawer.layers[layer].len:
+          sk.drawer.layers[layer][j].pos.y += dy
+
+    return currentPos - pos
+
+  let runedText = text.toRunes
   var i = 0
   while i < runedText.len:
     let rune = runedText[i]
@@ -614,33 +718,50 @@ proc getTextSize*(sk: Silky, font: string, text: string): Vec2 =
 
   let
     fontData = sk.atlas.fonts[font]
-    runedText = text.toRunes
   var
     currentPos = vec2(0, fontData.lineHeight)
     maxWidth = 0.0'f
 
-  for i in 0 ..< runedText.len:
-    let rune = runedText[i]
-    if rune == Rune(10):
-      maxWidth = max(maxWidth, currentPos.x)
-      currentPos.x = 0
-      currentPos.y += fontData.lineHeight
-      continue
+  if text.isAsciiText():
+    for i in 0 ..< text.len:
+      let ch = text[i]
+      if ch == '\n':
+        maxWidth = max(maxWidth, currentPos.x)
+        currentPos.x = 0
+        currentPos.y += fontData.lineHeight
+        continue
 
-    let glyphStr = $rune
-    var entry: LetterEntry
-    if glyphStr in fontData.entries:
-      entry = fontData.entries[glyphStr][0]
-    elif "?" in fontData.entries:
-      entry = fontData.entries["?"][0]
-    else:
-      continue
+      var entry: AsciiLetterEntry
+      if not fontData.lookupAsciiLetter(ch, 0, entry):
+        continue
 
-    currentPos.x += entry.advance
-    if i < runedText.len - 1:
-      let nextGlyphStr = $runedText[i + 1]
-      if nextGlyphStr in entry.kerning:
-        currentPos.x += entry.kerning[nextGlyphStr]
+      currentPos.x += entry.advance
+      if i < text.len - 1:
+        currentPos.x += fontData.lookupAsciiKerning(ch, text[i + 1])
+  else:
+    let runedText = text.toRunes
+    for i in 0 ..< runedText.len:
+      let rune = runedText[i]
+      if rune == Rune(10):
+        maxWidth = max(maxWidth, currentPos.x)
+        currentPos.x = 0
+        currentPos.y += fontData.lineHeight
+        continue
+
+      let glyphStr = $rune
+      var entry: LetterEntry
+      if glyphStr in fontData.entries:
+        entry = fontData.entries[glyphStr][0]
+      elif "?" in fontData.entries:
+        entry = fontData.entries["?"][0]
+      else:
+        continue
+
+      currentPos.x += entry.advance
+      if i < runedText.len - 1:
+        let nextGlyphStr = $runedText[i + 1]
+        if nextGlyphStr in entry.kerning:
+          currentPos.x += entry.kerning[nextGlyphStr]
 
   maxWidth = max(maxWidth, currentPos.x)
   vec2(maxWidth, currentPos.y)


### PR DESCRIPTION
## Summary
- add runtime-only ASCII glyph and kerning lookup tables after atlas decode/build
- route ASCII `drawText` and `getTextSize` through byte iteration instead of `toRunes` and per-glyph string keys
- keep the existing Unicode path for non-ASCII text
- store table-free ASCII glyph metrics so the hot path does not copy `LetterEntry.kerning` tables per glyph

## Why this belongs in Silky
Coworld uses Silky through the normal immediate-mode `text`, `button`, `checkBox`, `drawText`, and `getTextSize` APIs. The allocations fixed here happen inside those APIs for ordinary ASCII labels; every Silky app that draws common UI text benefits.

A/B proof from `coworld-vanilla-wow` PR 399 with Coworld terrain and GLTF fixes held constant:
- patched Silky: steady `renderer frame` ~1,716-1,786 alloc/free pairs per frame; `global ui` ~790/frame
- upstream Silky only: steady `renderer frame` regresses to ~17,155-17,674 alloc/free pairs per frame; `global ui` regresses to ~15,821/frame

Command:
`cd player && nim r -d:ProfileTracePath=/tmp/coworld-fluffy-upstream-silky.json -d:ProfileTicks=30 global_viewer.nim -- --replay=../docs/examples/plainstrider-session-replay.json`

## Verification
- `nim check src/silky/atlas.nim`
- `nim check src/silky/contexts.nim`
- downstream `nim check global_viewer.nim`
