### PR TITLE
Anchor subwindow resize handle to layout origin

### DIFF
--- a/src/silky/widgets.nim
+++ b/src/silky/widgets.nim
@@ -236,8 +236,8 @@ proc subWindowEnd*(sk: Silky, window: Window, subWindowState: SubWindowState) =
   let
     resizeHandleSize = sk.getImageSize("resize")
     resizeHandleRect = rect(
-      sk.at.x + sk.size.x - resizeHandleSize.x.float32 - sk.theme.border.float32,
-      sk.at.y + sk.size.y - resizeHandleSize.y.float32 - sk.theme.border.float32,
+      sk.pos.x + sk.size.x - resizeHandleSize.x.float32 - sk.theme.border.float32,
+      sk.pos.y + sk.size.y - resizeHandleSize.y.float32 - sk.theme.border.float32,
       resizeHandleSize.x.float32,
       resizeHandleSize.y.float32
     )


### PR DESCRIPTION
## Problem

The subwindow resize handle (the corner dragger) drew and hit-tested roughly twice as far down as it should, well below the window's bottom edge.

`subWindowEnd` anchored the handle to `sk.at` — the layout *cursor* — instead of `sk.pos`, the layout *origin*. Inside `subWindow`, the body's `frame(...)` resolves to the DSL `frame` (widgets' own `frame` is declared after the `subWindow` template, so the bare identifier binds at the instantiation site). The DSL's `finishNode` advances the parent cursor by the finished node's height, so by the time `subWindowEnd` runs, `sk.at.y` has already moved down past the body and `sk.at.y + sk.size.y` overshoots.

`sk.at.x` still equalled `sk.pos.x` — the cursor only advances vertically in a `TopToBottom` layout — which is why only y looked doubled.

## Fix

Use `sk.pos` for both axes.

Measured on the basicwindow example (window at 100,100, size 400x700):

| | handle rect |
| --- | --- |
| before | `(468, 1424, 22x22)` — 624px below the window |
| after | `(468, 768, 22x22)` — bottom-right corner, inset by the 10px border |

## Testing

- `examples/basicwindow` test suite passes
- `tests/test_semantic.nim` and `tests/test_cpu_backend.nim` pass
- the basicwindow example still compiles

## Note, not addressed here

The close button in `subWindowStart` has the same `sk.at`-instead-of-`sk.pos` anchoring, papered over with a `padding * 5` fudge. It lands roughly right today but will drift if the header icon or padding sizes change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)