### PR TITLE
Give outline-less glyphs finite bounds

### DIFF
--- a/src/silky/atlas.nim
+++ b/src/silky/atlas.nim
@@ -383,6 +383,16 @@ proc addDirRecursive*(builder: AtlasBuilder, path: string, removePrefix: string 
     if entry.kind == pcDir:
       builder.addDirRecursive(entry.path, removePrefix)
 
+proc finiteBounds(bounds: Rect): Rect =
+  ## Glyphs with no outline (such as space) compute to infinite/NaN bounds,
+  ## which poison the layout math later, so treat them as empty instead.
+  const Finite = {fcNormal, fcSubnormal, fcZero, fcNegZero}
+  if bounds.x.classify in Finite and bounds.y.classify in Finite and
+    bounds.w.classify in Finite and bounds.h.classify in Finite:
+    bounds
+  else:
+    rect(0, 0, 0, 0)
+
 proc addFont*(builder: AtlasBuilder, path: string, name: string, size: float32, chars: seq[string] = AsciiGlyphs, subpixelSteps: int = 0) =
   ## Add a font to the atlas.
   let fontAtlas = FontAtlas()
@@ -405,7 +415,7 @@ proc addFont*(builder: AtlasBuilder, path: string, name: string, size: float32, 
       glyphPath = typeface.getGlyphPath(rune)
       scale = fontObj.scale
       scaleMat = scale(vec2(scale))
-      baseBounds = glyphPath.computeBounds(scaleMat).snapToPixels()
+      baseBounds = glyphPath.computeBounds(scaleMat).snapToPixels().finiteBounds()
       advance = typeface.getAdvance(rune) * scale
     fontAtlas.entries[glyphStr] = @[]
     for variant in 0 ..< numVariants:

--- a/tests/test_atlas_png.nim
+++ b/tests/test_atlas_png.nim
@@ -1,7 +1,7 @@
 ## Tests for atlas JSON embedded inside PNG files.
 
 import
-  std/[os, tables],
+  std/[math, os, tables],
   pixie,
   silky/atlas
 
@@ -49,5 +49,19 @@ block:
   createDir(path.splitPath().head)
   image.writeFile(path)
   assertRaisesMissingChunk(path)
+
+block:
+  echo "Testing glyphs with no outline get finite bounds"
+  # A space has no path, so pixie reports infinite/NaN bounds for it. Those
+  # used to reach the atlas and stop text layout at the first space.
+  const Finite = {fcNormal, fcSubnormal, fcZero, fcNegZero}
+  let builder = newAtlasBuilder(256, 2)
+  builder.addFont("tests/data/IBMPlexSans-Regular.ttf", "Default", 16.0)
+  let entry = builder.atlas.fonts["Default"].entries[" "][0]
+  doAssert entry.boundsX.classify in Finite, $entry.boundsX
+  doAssert entry.boundsY.classify in Finite, $entry.boundsY
+  doAssert entry.boundsWidth.classify in Finite, $entry.boundsWidth
+  doAssert entry.boundsHeight.classify in Finite, $entry.boundsHeight
+  doAssert entry.advance > 0, $entry.advance
 
 echo "All atlas PNG tests passed."


### PR DESCRIPTION
Every string stopped rendering at its first space.

`pixie`'s `computeBounds` returns infinite/NaN bounds for a glyph with no outline, and a space is exactly that. Those values were baked into the atlas, so in `drawText` the vertical clip test

```nim
if glyphClip and currentPos.y + entry.boundsY >= maxPos.y:
  break
```

evaluated as `inf >= inf` and broke out of the glyph loop as soon as a space was reached. `"ui scale: (+/-)"` rendered as `ui`, and apps that draw text token-by-token got everything jammed together with no gaps.

The fix zeroes the bounds of outline-less glyphs at atlas build time and keeps their advance, so a space takes up its width and draws nothing.

## Verification

- New case in `tests/test_atlas_png.nim` asserts the space glyph's bounds are finite and its advance positive. It fails on master with `inf` and passes with the fix.
- `tests/test_atlas_png.nim` passes.
- `basicwindow`, `calculator`, `layouts`, `menu`, `panels`, `the7gui` all compile; `basicwindow` renders full strings again (before: `ui` / `frame`; after: `ui scale: (+/-)` / `frame time:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)