### PR TITLE
Make drawRoundedImage keep aspect ratio with centered cover fit

### DIFF
--- a/src/silky/contexts.nim
+++ b/src/silky/contexts.nim
@@ -788,7 +788,9 @@ proc drawRoundedImage*(
   radius: float32,
   color = rgbx(255, 255, 255, 255)
 ) {.measure.} =
-  ## Queues an atlas image draw stretched to size with rounded corners.
+  ## Queues an atlas image draw filling size with rounded corners.
+  ## The image keeps its aspect ratio: it is scaled uniformly to cover
+  ## the destination rect, centered, and the overflow is cropped.
   ## Builds the shape from an inner rect, four edge rects and four
   ## triangle fans, keeping UVs mapped to the destination rect throughout.
   if name notin sk.atlas.entries:
@@ -798,11 +800,12 @@ proc drawRoundedImage*(
     return
   let
     entry = sk.atlas.entries[name]
-    uvOrigin = vec2(entry.x.float32, entry.y.float32)
-    uvScale = vec2(
-      entry.width.float32 / size.x,
-      entry.height.float32 / size.y
-    )
+    entrySize = vec2(entry.width.float32, entry.height.float32)
+    cover = max(size.x / entrySize.x, size.y / entrySize.y)
+    uvOrigin =
+      vec2(entry.x.float32, entry.y.float32) +
+      (entrySize - size / cover) / 2
+    uvScale = vec2(1 / cover, 1 / cover)
     r = clamp(radius, 0.0'f, min(size.x, size.y) / 2)
 
   template uvAt(p: Vec2): Vec2 =


### PR DESCRIPTION
## What

Follow-up to #64 — this commit was pushed to the `rounded-image` branch just after that PR merged, so it never landed.

`drawRoundedImage` now keeps the image's aspect ratio instead of stretching: the image is scaled uniformly to cover the destination rect, centered, and the overflow is cropped (CSS `object-fit: cover` behavior).

## How

Only the UV mapping changes; the nine-piece geometry is untouched. A uniform cover scale (`max(size.x / imgW, size.y / imgH)`) shifts the UV origin to a centered, aspect-matched sub-rect of the atlas entry, and all rect and fan vertices map through that shared sub-rect, so UVs stay continuous across pieces.

## Verified

Framebuffer captures via `tests/manual_rounded_image.nim --screenshot`: a wide 300x200 rect crops the source's top/bottom rows, a tall 150x400 rect crops the left/right columns, and in both the color-block proportions match the original 48x48 `debug.9patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)